### PR TITLE
OSVDB 90738 affects 4.0.0.beta1 and 4.0.0.beta2

### DIFF
--- a/gems/passenger/OSVDB-90738.yml
+++ b/gems/passenger/OSVDB-90738.yml
@@ -13,4 +13,4 @@ cvss_v2: 2.1
 patched_versions:
   - ">= 4.0.0"
 unaffected_versions:
-  - "< 4.0.0"
+  - "< 4.0.0.beta"


### PR DESCRIPTION
Closes #151ruby-advisory-db